### PR TITLE
Age Regrouping

### DIFF
--- a/age/data/load/regroup.py
+++ b/age/data/load/regroup.py
@@ -1,0 +1,55 @@
+from age.data.load import utils
+import rpy2.robjects as robjects
+from rpy2.robjects.packages import importr
+from collections import defaultdict
+from typing import List
+import numpy as np
+
+# Need to have R package ungroup installed 
+# https://cran.rstudio.com/web/packages/ungroup/index.html
+importr('ungroup')
+
+def _group_year_counts(counts, new_ages, start_count_age=0):
+    new_counts = defaultdict(int)
+    for age in new_ages:
+        lower, upper = age_string_to_tuple(age)
+        for i, count in enumerate(counts, start_count_age):
+            if i > upper: # small performance optimization
+                break
+            if lower <= i <= upper:
+                new_counts[age] += count
+    return list(new_counts.values())
+    
+def regroup_counts_pclm(ages: List[str], counts: List[int], new_ages: List[str] = None, 
+                       max_age: int = 110) -> (List[str], List[float]):
+    '''Regroup histogram count data for new age ranges. Uses the pclm method from the 
+    R ungroup package https://cran.rstudio.com/web/packages/ungroup/ungroup.pdf
+
+    Args:
+        ages: list of age ranges in string format.
+        counts: list of counts (eg deaths) corresponding to age ranges.
+        new_ages: If None, the ages are in yearly increments. Otherwise provide a list. (default None)
+        max_age -- This is the bound of the final unbounded age range when fitting. (default 110)
+    Returns:
+    (list of new age ranges, list of counts for new age ranges)
+    '''
+    ages = sorted([utils.age_string_to_tuple(i)[0] for i in ages])
+    # define R functions
+    pclm = robjects.r['pclm']
+    fitted = robjects.r['fitted']
+    # nlast: Length of the last interval
+    nlast = max_age - ages[-1]
+    # get new counts in year-long intervals
+    ages_r = robjects.IntVector(ages)
+    counts_r = robjects.IntVector(counts)
+    res = pclm(ages_r, counts_r, nlast)
+    new_counts = list(fitted(res))
+    
+    # create new age ranges
+    min_age = ages[0]
+    if new_ages == None:
+        new_ages = [f'{i}-{i}' for i in range(min_age, max_age)]
+    else:
+        new_counts = _group_year_counts(new_counts, new_ages, start_count_age=min_age)
+    
+    return (new_ages, new_counts)

--- a/age/data/load/utils.py
+++ b/age/data/load/utils.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import datetime
+import numpy as np
 
 def map_age(age):
     """Map ages to standard buckets."""
@@ -22,3 +23,13 @@ def last_day_of_calenderweek(year, week):
     first = datetime.date(year, 1, 1)
     base = 1 if first.isocalendar()[1] == 1 else 8
     return first + datetime.timedelta(days=base - first.isocalendar()[2] + 7 * (week - 1) + 6)
+
+
+def age_string_to_tuple(ages: str) -> (int, int):
+    '''Converts string age format to tuple of integers (lower, upper).
+    Eg. \'10-14\' becomes (10, 14), or \'85+' to (85, np.float(inf))
+    '''
+    if '+' in ages:
+        return (int(ages[:-1]), np.float('inf'))
+    else:
+        return tuple([int(i) for i in ages.split('-')]) 


### PR DESCRIPTION
This feature regroups any count data for arbitrary age ranges using the R [ungroup package](https://cran.rstudio.com/web/packages/ungroup/index.html). For example, 
```python
regroup_counts_pclm(['0-2', '3-4'], [2,5], max_age=5)
# output (['0-0', '1-1', '2-2', '3-3', '4-4'], [0.41, 0.81, 1.44, 2.09, 2.21])
regroup_counts_pclm(['0-2', '3-6', '7+'], [3,9,12], new_ages=['0-1', '2-5', '6+'])
# output (['0-1', '2-5', '6+'], [2.01, 7.4, 16.9])
```
Some design questions:
- the method comes with confidence intervals as well, but not currently returning them. Are they useful?
- currently, `new_ages` is optional. If its None (default), it uses year-increments. Might make sense to make this non-optional, and force user to give new age ranges.
- The output is a tuple currently. Might make sense to rather give it as a dictionary of pandas dataframe
- the new counts from the method are not integers. Should this function do the rounding? Note that the rounding can violate a basic consistency criteria (the total counts should remain invariant post re-grouping)